### PR TITLE
修正question和exam的逻辑，使得exam统一管理所有“测验”类的实体

### DIFF
--- a/deploy/src/main/java/org/nuist/bo/ExamBO.java
+++ b/deploy/src/main/java/org/nuist/bo/ExamBO.java
@@ -1,5 +1,6 @@
 package org.nuist.bo;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -19,6 +20,9 @@ public class ExamBO {
     private String description;
     private Long courseId;
     private Long teacherId;
+    private Long knowledgeId;
+    @Schema(description = "Exam的类型（考试、课后习题等）")
+    private String type;
     private Long totalScore;
     private Integer durationMinutes;
     private LocalDateTime startTime;
@@ -34,6 +38,8 @@ public class ExamBO {
                 .description(examPo.getDescription())
                 .courseId(examPo.getCourseId())
                 .teacherId(examPo.getTeacherId())
+                .type(examPo.getType())
+                .knowledgeId(examPo.getKnowledgeId())
                 .totalScore(examPo.getTotalScore())
                 .durationMinutes(examPo.getDurationMinutes())
                 .startTime(examPo.getStartTime())
@@ -51,6 +57,8 @@ public class ExamBO {
         examPo.setDescription(description);
         examPo.setCourseId(courseId);
         examPo.setTeacherId(teacherId);
+        examPo.setType(type);
+        examPo.setKnowledgeId(knowledgeId);
         examPo.setTotalScore(totalScore);
         examPo.setDurationMinutes(durationMinutes);
         examPo.setStartTime(startTime);

--- a/deploy/src/main/java/org/nuist/bo/QuestionBO.java
+++ b/deploy/src/main/java/org/nuist/bo/QuestionBO.java
@@ -1,5 +1,6 @@
 package org.nuist.bo;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -19,7 +20,9 @@ public class QuestionBO {
     private String content;
     private String questionType;
     private String difficulty;
+    @Schema(description = "问题关联的知识点ID | 该字段仅做预留，目前不应当有任何业务作用")
     private Long knowledgeId;
+    private Long examId;
     private String referenceAnswer;
     private Long scorePoints;
     private String answer;
@@ -34,6 +37,7 @@ public class QuestionBO {
                 .questionType(questionPo.getQuestionType())
                 .difficulty(questionPo.getDifficulty())
                 .knowledgeId(questionPo.getKnowledgeId())
+                .examId(questionPo.getExamId())
                 .referenceAnswer(questionPo.getReferenceAnswer())
                 .scorePoints(questionPo.getScorePoints())
                 .answer(questionPo.getAnswer())
@@ -50,6 +54,7 @@ public class QuestionBO {
         questionPo.setQuestionType(questionType);
         questionPo.setDifficulty(difficulty);
         questionPo.setKnowledgeId(knowledgeId);
+        questionPo.setExamId(examId);
         questionPo.setReferenceAnswer(referenceAnswer);
         questionPo.setScorePoints(scorePoints);
         questionPo.setAnswer(answer);

--- a/deploy/src/main/java/org/nuist/controller/ExamController.java
+++ b/deploy/src/main/java/org/nuist/controller/ExamController.java
@@ -47,6 +47,11 @@ public class ExamController{
         return ResponseEntity.ok(examService.getExamsByTeacherInCourse(courseId, teacherId));
     }
 
+    @GetMapping("/course/{courseId}/type/{type}")
+    public ResponseEntity<List<ExamBO>> getExamsInCourseByType(@PathVariable Long courseId, @PathVariable String type) {
+        return ResponseEntity.ok(examService.getExamsInCourseByType(courseId, type));
+    }
+
     @PostMapping("/save")
     
     public ResponseEntity<ExamBO> saveExam(@RequestBody ExamBO examBo) {

--- a/deploy/src/main/java/org/nuist/controller/QuestionController.java
+++ b/deploy/src/main/java/org/nuist/controller/QuestionController.java
@@ -1,5 +1,6 @@
 package org.nuist.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -47,7 +48,7 @@ public class QuestionController {
     }
 
     @GetMapping("/knowledge/{knowledgeId}")
-    
+    @Operation(summary = "查找属于一个知识点的课后习题", description = "实现为通过exam找出属于一个知识点的课后习题exam，并返回对应question")
     public ResponseEntity<List<QuestionBO>> getQuestionsByKnowledge(@PathVariable Long knowledgeId) {
         return ResponseEntity.ok(questionService.getQuestionsByKnowledgeId(knowledgeId));
     }
@@ -67,7 +68,7 @@ public class QuestionController {
     }
 
     @PostMapping("/save")
-    
+    @Operation(summary = "保存一个问题", description = "目前，所有问题应当与考试关联（通过examId），考试再与知识点关联")
     public ResponseEntity<QuestionBO> saveQuestion(@RequestBody QuestionBO questionBO) {
         return ResponseEntity.ok(questionService.saveQuestion(questionBO));
     }

--- a/deploy/src/main/java/org/nuist/po/ExamPo.java
+++ b/deploy/src/main/java/org/nuist/po/ExamPo.java
@@ -40,6 +40,16 @@ public class ExamPo {
     private Long teacherId;
 
     /**
+     * 考试、课后习题等类型
+     */
+    private String type;
+
+    /**
+     * 若是课后习题，则记录关联的知识点
+     */
+    private Long knowledgeId;
+
+    /**
      * 试卷满分
      */
     @TableField("total_score")

--- a/deploy/src/main/java/org/nuist/po/QuestionPo.java
+++ b/deploy/src/main/java/org/nuist/po/QuestionPo.java
@@ -30,6 +30,9 @@ public class QuestionPo {
     @TableField("knowledge_id")
     private Long knowledgeId;
 
+    @TableField("exam_id")
+    private Long examId;
+
     @TableField("reference_answer")
     private String referenceAnswer;
 

--- a/deploy/src/main/java/org/nuist/service/ExamService.java
+++ b/deploy/src/main/java/org/nuist/service/ExamService.java
@@ -35,6 +35,14 @@ public interface ExamService {
     List<ExamBO> getExamsByTeacherInCourse(Long courseId, Long teacherId);
 
     /**
+     * 在课程中按照类型（考试/练习题）来查找exam
+     * @param courseId 课程ID
+     * @param type 类型
+     * @return 考试列表
+     */
+    List<ExamBO> getExamsInCourseByType(Long courseId, String type);
+
+    /**
      * 持久化一个考试实体
      * @param examBo dto
      * @return 持久化后的业务对象（附带主键和时间字段）

--- a/deploy/src/main/java/org/nuist/service/impl/ExamServiceImpl.java
+++ b/deploy/src/main/java/org/nuist/service/impl/ExamServiceImpl.java
@@ -8,6 +8,7 @@ import org.nuist.po.ExamPo;
 import org.nuist.service.ExamService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -64,17 +65,22 @@ public class ExamServiceImpl implements ExamService {
     }
 
     @Override
+    public List<ExamBO> getExamsInCourseByType(Long courseId, String type) {
+        if (courseId == null || !StringUtils.hasText(type)) {
+            return new ArrayList<>();
+        }
+        return convertToExamBO(
+                examMapper.selectList(
+                        Wrappers.<ExamPo>lambdaQuery()
+                                .eq(ExamPo::getCourseId, courseId)
+                                .eq(ExamPo::getType, type)
+                )
+        );
+    }
+
+    @Override
     public ExamBO saveExam(ExamBO examBo) {
-        ExamPo persistedExamPo = new ExamPo();
-        persistedExamPo.setTitle(examBo.getTitle());
-        persistedExamPo.setDescription(examBo.getDescription());
-        persistedExamPo.setCourseId(examBo.getCourseId());
-        persistedExamPo.setTeacherId(examBo.getTeacherId());
-        persistedExamPo.setTotalScore(examBo.getTotalScore());
-        persistedExamPo.setDurationMinutes(examBo.getDurationMinutes());
-        persistedExamPo.setStartTime(examBo.getStartTime());
-        persistedExamPo.setEndTime(examBo.getEndTime());
-        persistedExamPo.setStatus(examBo.getStatus());
+        ExamPo persistedExamPo = examBo.toExam();
 
         examMapper.insert(persistedExamPo);
         return ExamBO.fromExam(persistedExamPo);

--- a/deploy/src/main/java/org/nuist/service/impl/QuestionServiceImpl.java
+++ b/deploy/src/main/java/org/nuist/service/impl/QuestionServiceImpl.java
@@ -75,7 +75,8 @@ public class QuestionServiceImpl extends ServiceImpl<QuestionMapper, QuestionPo>
         }
         return convertToQuestionBO(
                 list(Wrappers.<QuestionPo>lambdaQuery()
-                        .eq(QuestionPo::getKnowledgeId, knowledgeId)));
+                        .apply("exam_id IN (SELECT exam_id FROM exam ex WHERE ex.knowledge_id = {0})", knowledgeId)
+                ));
     }
 
     @Override
@@ -89,8 +90,9 @@ public class QuestionServiceImpl extends ServiceImpl<QuestionMapper, QuestionPo>
         if (knowledgeId == null) {
             return new ArrayList<>();
         }
-        // 仅包含一个知识点中的问题
-        LambdaQueryWrapper<QuestionPo> wrapper = Wrappers.<QuestionPo>lambdaQuery().eq(QuestionPo::getKnowledgeId, knowledgeId);
+        // 仅包含一个知识点中的问题，通过exam作中间关联
+        LambdaQueryWrapper<QuestionPo> wrapper = Wrappers.<QuestionPo>lambdaQuery()
+                .apply("exam_id IN (SELECT exam_id FROM exam ex WHERE ex.knowledge_id = {0})", knowledgeId);
 
         // 筛选问题类型
         if (StringUtils.hasText(questionType)) {


### PR DESCRIPTION
1. 修改数据表定义：为exam表添加type字段（表示该测验的类型，考试/课后练习/作业 等等）、添加可选的knowledge_id字段（如果是课后习题，可以用该字段关联）
2. 修改数据表定义：为question添加exam_id字段，使得一个问题能够关联到一场测验
3. 修改对应的业务代码实现